### PR TITLE
Caracara 0.5.x Migration

### DIFF
--- a/falcon_toolkit/common/cli.py
+++ b/falcon_toolkit/common/cli.py
@@ -39,7 +39,7 @@ def get_instance(ctx: click.Context):
 
 def parse_cli_filters(filter_kv_strings: List[str], client: Client) -> FalconFilter:
     """Parse consecutive chains of -f filters into a FalconFilter object for later use."""
-    filters = client.FalconFilter()
+    filters = client.FalconFilter(dialect='hosts')
     for filter_kv_string in filter_kv_strings:
         if '=' not in filter_kv_string:
             raise ValueError("Filter key=value string is in the wrong format")

--- a/falcon_toolkit/falcon.py
+++ b/falcon_toolkit/falcon.py
@@ -290,6 +290,7 @@ def cli_list_filters():
         click.echo(host_filters[unique_filter_name]['help'])
         click.echo()
 
+
 # Load all commands into the main cli object, ready for use as root falcon commands
 cli.add_command(cli_host_search)
 cli.add_command(cli_list_filters)

--- a/falcon_toolkit/falcon.py
+++ b/falcon_toolkit/falcon.py
@@ -33,8 +33,7 @@ import sys
 import click
 import pick
 
-from caracara.filters.fql import FalconFilterAttribute
-from caracara.modules.hosts import FILTER_ATTRIBUTES as HOSTS_FILTER_ATTRIBUTES
+from caracara_filters.dialects import DIALECTS
 from colorama import (
     deinit as colorama_deinit,
     init as colorama_init,
@@ -277,14 +276,19 @@ def profiles_new(ctx: click.Context):
 )
 def cli_list_filters():
     """List all possible filters out on screen based on data available within Caracara."""
-    for hosts_filter_attribute in HOSTS_FILTER_ATTRIBUTES:
-        hosts_filter_attribute_obj: FalconFilterAttribute = hosts_filter_attribute()
-        click.echo(click.style(hosts_filter_attribute_obj.name, fg='blue', bold=True))
-        click.echo(click.style(hosts_filter_attribute_obj.description, dim=True))
-        click.echo(hosts_filter_attribute_obj.example())
+    host_filters: dict = DIALECTS['hosts']
 
+    # We have some duplicate filters with an underscore added for FQL compatability
+    unique_filters = set()
+    for key in host_filters:
+        unique_filters.add(key.replace("_", ""))
+
+    unique_filters = sorted(list(unique_filters))
+
+    for unique_filter_name in unique_filters:
+        click.echo(click.style(unique_filter_name, fg='blue', bold=True))
+        click.echo(host_filters[unique_filter_name]['help'])
         click.echo()
-
 
 # Load all commands into the main cli object, ready for use as root falcon commands
 cli.add_command(cli_host_search)

--- a/poetry.lock
+++ b/poetry.lock
@@ -172,18 +172,31 @@ cffi = ">=1.0.0"
 
 [[package]]
 name = "caracara"
-version = "0.3.0"
+version = "0.5.1"
 description = "The CrowdStrike Falcon Developer Toolkit"
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.7.2,<4.0.0"
 files = [
-    {file = "caracara-0.3.0-py3-none-any.whl", hash = "sha256:d13056627d31ba6c030534ba300fbe5a36ccfc9ecf67c188865533216e4d0579"},
-    {file = "caracara-0.3.0.tar.gz", hash = "sha256:24034c20d8d62300cc8bd9c130985abc6f4266b16d6080cdbee4e108d167dc6a"},
+    {file = "caracara-0.5.1-py3-none-any.whl", hash = "sha256:2285bfc4571418d90cbd0488772f9c5b86f4137cd8db6f1d671cac61e1c8a443"},
+    {file = "caracara-0.5.1.tar.gz", hash = "sha256:49386f32d4f404abe48ff06824b60a539e481beef381370a52a59cfed274eaba"},
 ]
 
 [package.dependencies]
+caracara-filters = ">=0.1.2,<0.2.0"
 crowdstrike-falconpy = ">=1.2.15,<2.0.0"
 py7zr = ">=0.20,<0.21"
+setuptools = ">=67.8.0,<68.0.0"
+
+[[package]]
+name = "caracara-filters"
+version = "0.1.4"
+description = "FQL generation engine for Caracara"
+optional = false
+python-versions = ">=3.7.2,<4.0.0"
+files = [
+    {file = "caracara_filters-0.1.4-py3-none-any.whl", hash = "sha256:d9a39510cc40cfc2cf9f6115314bb65acd71af96eb662e6b93a3c1262ca97ef8"},
+    {file = "caracara_filters-0.1.4.tar.gz", hash = "sha256:5d28a3be0c8d88f6b03555f2aff7530b6dd55f9fa43ae570a3c5fea5123651af"},
+]
 
 [[package]]
 name = "certifi"
@@ -438,13 +451,13 @@ files = [
 
 [[package]]
 name = "crowdstrike-falconpy"
-version = "1.2.16"
+version = "1.3.0"
 description = "The CrowdStrike Falcon SDK for Python 3"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "crowdstrike-falconpy-1.2.16.tar.gz", hash = "sha256:ff197727eb60cb130b2d45640ad05147647b7cfdad9797d101768264e7bb134b"},
-    {file = "crowdstrike_falconpy-1.2.16-py3-none-any.whl", hash = "sha256:f04f502f92a89b78d4e8c137a6611eab1be8a550bbdc5ca536ce2b18a970c6f8"},
+    {file = "crowdstrike-falconpy-1.3.0.tar.gz", hash = "sha256:907614de3a56fecc196e6ae9b4bd4eb61114f9a2f2c5e5ff5545660caea5ad76"},
+    {file = "crowdstrike_falconpy-1.3.0-py3-none-any.whl", hash = "sha256:a90328c37e173970f636695c50f1902ed6c469ba60c5fbb48cc91c92fad6c549"},
 ]
 
 [package.dependencies]
@@ -515,13 +528,13 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.2"
+version = "1.1.3"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
-    {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
 ]
 
 [package.extras]
@@ -906,13 +919,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "py7zr"
-version = "0.20.5"
+version = "0.20.6"
 description = "Pure python 7-zip library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "py7zr-0.20.5-py3-none-any.whl", hash = "sha256:17fe8bb9379ef1d416e6e400f29158ad71dc409869c7206d880441c70806f07f"},
-    {file = "py7zr-0.20.5.tar.gz", hash = "sha256:6fb4889c0fa32581818a3366984083253585d6c794e82c3242b8a12d6aeaabd3"},
+    {file = "py7zr-0.20.6-py3-none-any.whl", hash = "sha256:c7cfb7183fb8f48038f1036a116ca89dc8bd57979d05b75567f00e88a5afe698"},
+    {file = "py7zr-0.20.6.tar.gz", hash = "sha256:d036dee11fce69ad8d4fa86025ccfc4a3511ec27ee1c6b5bd8d6759313dbd077"},
 ]
 
 [package.dependencies]
@@ -1448,6 +1461,22 @@ cryptography = ">=2.0"
 jeepney = ">=0.6"
 
 [[package]]
+name = "setuptools"
+version = "67.8.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
+    {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
@@ -1678,4 +1707,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "11418d6d1466309ee9d4128f492e1277fff5f8b39e3dc9cf653c1d327da13c69"
+content-hash = "a6bd9e8e7304eb2e3d654ad6fe337027fb75745e834215485108134e5972f428"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "falcon-toolkit"
-version = "3.2.1"
+version = "3.3.0"
 description = "Toolkit to interface with CrowdStrike Falcon via the API"
 license = "MIT"
 authors = [
@@ -30,7 +30,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-caracara = "^0.3.0"
+caracara = "^0.5.1"
 click = "^8.1.3"
 click-option-group = "^0.5.3"
 click-spinner = "^0.1.10"


### PR DESCRIPTION
This PR sets up Falcon Toolkit to use Caracara 0.5.1 and Caracara-Filters 0.1.4 at minimum. This brings significant improvements to the filtering system.

Resolves #40.