### PR TITLE
CID Command Line Option for MSSP Auth Backend

### DIFF
--- a/falcon_toolkit/common/auth.py
+++ b/falcon_toolkit/common/auth.py
@@ -18,6 +18,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from caracara import Client
+    from click import Context
 
 
 class AuthBackend(ABC):
@@ -51,7 +52,7 @@ class AuthBackend(ABC):
         """
 
     @abstractmethod
-    def authenticate(self) -> Client:
+    def authenticate(self, ctx: Context) -> Client:
         """Return a complete OAuth2 object, ready for use with FalconPy."""
 
     @abstractmethod

--- a/falcon_toolkit/common/auth_backends/public_mssp.py
+++ b/falcon_toolkit/common/auth_backends/public_mssp.py
@@ -4,8 +4,6 @@ This authentication backend can take public cloud API keys (US-1, US-2, EU-1), a
 user which child CID to authenticate against.
 """
 
-import os
-
 from typing import Dict, Optional
 
 import click
@@ -104,14 +102,7 @@ class PublicCloudFlightControlParentCIDBackend(AuthBackend):
 
     def authenticate(self, ctx: click.Context) -> Client:
         """Log the Toolkit into Falcon using the settings and keys configured at instance setup."""
-
-        # We allow loading of an MSSP CID from the environment
-        chosen_cid_str = os.environ.get("FALCON_TOOLKIT_MSSP_CHILD_CID")
-
-        # ...but the one passed on the CLI always takes precedence
-        chosen_cid_str_ctx = ctx.obj["cid"]
-        if chosen_cid_str_ctx:
-            chosen_cid_str = chosen_cid_str_ctx
+        chosen_cid_str = ctx.obj["cid"]
 
         parent_client = Client(
             client_id=self.client_id,

--- a/falcon_toolkit/common/auth_backends/public_single_cid.py
+++ b/falcon_toolkit/common/auth_backends/public_single_cid.py
@@ -6,6 +6,7 @@ an OAuth2 object suitable for authenticating with FalconPy.
 
 from typing import Dict, Optional
 
+import click
 import keyring
 
 from caracara import Client
@@ -89,7 +90,7 @@ class PublicCloudSingleCIDBackend(AuthBackend):
 
         return config
 
-    def authenticate(self) -> Client:
+    def authenticate(self, ctx: click.Context) -> Client:
         """Log the Toolkit into Falcon using the settings and keys configured at instance setup."""
         client = Client(
             client_id=self.client_id,

--- a/falcon_toolkit/containment/cli.py
+++ b/falcon_toolkit/containment/cli.py
@@ -66,7 +66,7 @@ def cli_containment(
 ):
     """Manage the containment status of hosts in Falcon."""
     instance = get_instance(ctx)
-    client: Client = instance.auth_backend.authenticate()
+    client: Client = instance.auth_backend.authenticate(ctx)
     ctx.obj["client"] = client
 
     device_ids = None

--- a/falcon_toolkit/falcon.py
+++ b/falcon_toolkit/falcon.py
@@ -86,11 +86,22 @@ from falcon_toolkit.shell.cli import cli_shell
         "profile (Falcon Tenant) set up, this parameter is not required."
     ),
 )
+@click.option(
+    "--cid",
+    envvar="FALCON_TOOLKIT_CID",
+    type=click.STRING,
+    default=None,
+    help=(
+        "Specify the CID to connect to. Note that this only applies to authentication backends "
+        "(e.g., MSSP) that support multiple CIDs through the same set of API keys."
+    ),
+)
 def cli(
     ctx: click.Context,
     config_path: str,
     verbose: bool,
     profile: str,
+    cid: str,
 ):
     r"""Falcon Toolkit.
 
@@ -205,7 +216,10 @@ def cli(
     ctx.obj["log_filename_base"] = log_filename_base
 
     # Pass a profile name down the chain in case one is selected
-    ctx.obj['profile_name'] = profile
+    ctx.obj["profile_name"] = profile
+
+    # Store the CID in the context for optional use later
+    ctx.obj["cid"] = cid
 
 
 @cli.result_callback()

--- a/falcon_toolkit/hosts/cli.py
+++ b/falcon_toolkit/hosts/cli.py
@@ -55,7 +55,7 @@ def cli_host_search(
 ):
     """Implement the host_search CLI command."""
     instance = get_instance(ctx)
-    client = instance.auth_backend.authenticate()
+    client = instance.auth_backend.authenticate(ctx)
     filters = parse_cli_filters(filter_kv_strings, client)
 
     # Handle validation of the CSV export path here, before the search executes in host_search_cmd.

--- a/falcon_toolkit/maintenance_token/cli.py
+++ b/falcon_toolkit/maintenance_token/cli.py
@@ -75,7 +75,7 @@ def cli_maintenance_token(
 ):
     """Get system maintenance tokens from Falcon."""
     instance = get_instance(ctx)
-    client: Client = instance.auth_backend.authenticate()
+    client: Client = instance.auth_backend.authenticate(ctx)
     ctx.obj["client"] = client
 
     # Bulk token is a special case we can handle here.

--- a/falcon_toolkit/policies/cli.py
+++ b/falcon_toolkit/policies/cli.py
@@ -57,7 +57,7 @@ def cli_policies(
 ):
     """Configure the future profiles commands by getting the context in shape."""
     instance = get_instance(ctx)
-    client: Client = instance.auth_backend.authenticate()
+    client: Client = instance.auth_backend.authenticate(ctx)
     ctx.obj["client"] = client
 
     if prevention_policies_option:

--- a/falcon_toolkit/shell/cli.py
+++ b/falcon_toolkit/shell/cli.py
@@ -122,7 +122,7 @@ def cli_shell(  # pylint: disable=too-many-arguments,too-many-locals
     start the REPL command loop. This passes control over to the shell, via the Cmd2 library.
     """
     instance = get_instance(ctx)
-    client = instance.auth_backend.authenticate()
+    client = instance.auth_backend.authenticate(ctx)
 
     # Show online hosts only if queueing is false
     online_state = None if queueing else OnlineState.ONLINE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "falcon-toolkit"
-version = "3.4.1"
+version = "3.4.2"
 description = "Toolkit to interface with CrowdStrike Falcon via the API"
 license = "MIT"
 authors = [


### PR DESCRIPTION
The status quo is that you have to search for the CID you are working with every time you launch the Toolkit if you are an MSSP customer. This change allows you to specify the CID in either an environment variable or as a command line option (`--cid`).

This change is also available generically to other auth backends should they be available in the future.

Additionally, by passing the Click Context through to the `authenticate()` function, we pave the way for other parameters to be passed through to authentication backends in the future if required.

Note that we have a breaking change here. The only supported environment variable to set the CID for an auth backend that supports it (like the MSSP one) will be `FALCON_TOOLKIT_CID`. The other (`FALCON_MSSP_CHILD_CID`) has been removed, since it wasn't consistent and the new one is simpler and generalised. Apologies for any inconvenience caused.