### PR TITLE
Fixes RTR tar command

### DIFF
--- a/falcon_toolkit/shell/parsers.py
+++ b/falcon_toolkit/shell/parsers.py
@@ -555,7 +555,6 @@ tar_argparser.add_argument(
     "-f",
     "--filename",
     help="Target tar filename. Relative or absolute.",
-    nargs=1,
     dest="filename",
 )
 tar_create_update_argparser = tar_argparser.add_mutually_exclusive_group(required=True)

--- a/falcon_toolkit/shell/prompt.py
+++ b/falcon_toolkit/shell/prompt.py
@@ -1043,7 +1043,7 @@ class RTRPrompt(Cmd):
         tar_file = args.filename
         mode = "-c" if args.create else "-u"
         source = args.source
-        if args.auto:
+        if args.compress_auto:
             compression = "-a"
         elif args.gzip:
             compression = "-z"


### PR DESCRIPTION
G'day, the RTR tar command is currently broken due to a mismatched variable name and the filename being interpolated as a list. This PR corrects both problems so tar works as expected in the RTR shell.