### PR TITLE
Fix missing recursive zip argument

### DIFF
--- a/falcon_toolkit/shell/parsers.py
+++ b/falcon_toolkit/shell/parsers.py
@@ -693,6 +693,13 @@ zip_argparser.add_argument(
     "destination",
     help="Target zip file name. Relative or absolute path.",
 )
+zip_argparser.add_argument(
+    "-r",
+    "--recurse-paths",
+    help="[Linux/macOS] Travel the directory structure recursively",
+    action="store_true",
+    dest="recursive",
+)
 
 _PARSERS = {
     "cat": cat_argparser,

--- a/falcon_toolkit/shell/prompt.py
+++ b/falcon_toolkit/shell/prompt.py
@@ -1096,5 +1096,8 @@ class RTRPrompt(Cmd):
     @with_argparser(PARSERS.zip, preserve_quotes=True)
     def do_zip(self, args):
         """Compress a file or directory into a zip file."""
-        command = f"zip {args.source} {args.destination}"
+        if args.recursive:
+            command = f"zip -r {args.source} {args.destination}"
+        else:
+            command = f"zip {args.source} {args.destination}"
         self.send_generic_command(command)


### PR DESCRIPTION
This PR fixes the missing recursive (`-r`) argument for the RTR zip command on Linux and macOS. 

Discussed in #217 (part 1).