### PR TITLE
Add rmdir and pwd RTR commands

### DIFF
--- a/falcon_toolkit/shell/parsers.py
+++ b/falcon_toolkit/shell/parsers.py
@@ -474,6 +474,19 @@ rm_argparser.add_argument(
     action="store_true",
 )
 
+rmdir_argparser = Cmd2ArgumentParser()
+rmdir_argparser.add_argument(
+    "directory",
+    help="Empty directory to delete",
+)
+rmdir_argparser.add_argument(
+    "-p",
+    "--parents",
+    dest="parents",
+    help="Remove directory and its ancestors",
+    action="store_true",
+)
+
 run_argparser = Cmd2ArgumentParser()
 run_argparser.add_argument(
     "executable",
@@ -724,9 +737,11 @@ _PARSERS = {
     "put": put_argparser,
     "put_and_run": put_and_run_argparser,
     "put_files": Cmd2ArgumentParser(),
+    "pwd": Cmd2ArgumentParser(),
     "reg": reg_argparser,
     "restart": restart_argparser,
     "rm": rm_argparser,
+    "rmdir": rmdir_argparser,
     "run": run_argparser,
     "runscript": runscript_argparser,
     "shutdown": shutdown_argparser,

--- a/falcon_toolkit/shell/prompt.py
+++ b/falcon_toolkit/shell/prompt.py
@@ -956,6 +956,11 @@ class RTRPrompt(Cmd):
                 self.poutput(Style.RESET_ALL + put_file["description"])
             self.poutput()
 
+    @with_argparser(PARSERS.pwd, preserve_quotes=True)
+    def do_pwd(self, args):
+        """[Linux/macOS] Print the full filename of the current working directory."""
+        self.send_generic_command("pwd")
+
     @with_argparser(PARSERS.reg, preserve_quotes=True)
     def do_reg(self, args):
         """[Windows] Registry manipulation. Subcommands: delete, load, query, set, unload."""
@@ -984,6 +989,16 @@ class RTRPrompt(Cmd):
             command = f"rm {args.path} -Force"
         else:
             command = f"rm {args.path}"
+
+        self.send_generic_command(command)
+
+    @with_argparser(PARSERS.rmdir, preserve_quotes=True)
+    def do_rmdir(self, args):
+        """[Linux] Remove (delete) empty directories."""
+        if args.parents:
+            command = f"rmdir -p {args.directory}"
+        else:
+            command = f"rmdir {args.directory}"
 
         self.send_generic_command(command)
 


### PR DESCRIPTION
This PR adds support for the `rmdir` Linux RTR command and the `pwd` RTR command on Linux and macOS.

Note: This PR depends on a hotfix to caracara to support these additional features and a bump to the minimum required caracara version: CrowdStrike/caracara#289