### PR TITLE
Feature/rtr flags

### DIFF
--- a/falcon_toolkit/shell/parsers.py
+++ b/falcon_toolkit/shell/parsers.py
@@ -281,6 +281,13 @@ mkdir_argparser.add_argument(
     "directory",
     help="Name of new directory to create",
 )
+mkdir_argparser.add_argument(
+    "-p",
+    "--parents",
+    dest="parents",
+    help="[Linux/macOS] Create directory and its parents",
+    action="store_true",
+)
 
 mount_argparser = Cmd2ArgumentParser()
 mount_subparsers = mount_argparser.add_subparsers(

--- a/falcon_toolkit/shell/parsers.py
+++ b/falcon_toolkit/shell/parsers.py
@@ -467,10 +467,25 @@ rm_argparser.add_argument(
     "path",
     help="File or directory to delete",
 )
-rm_argparser.add_argument(
+rm_group = rm_argparser.add_mutually_exclusive_group()
+rm_group.add_argument(
     "-Force",
     dest="force",
-    help="Flag to allow directory and recursive deletes",
+    help="[Windows] Flag to allow directory and recursive deletes",
+    action="store_true",
+)
+rm_group.add_argument(
+    "-r",
+    "--recursive",
+    dest="recursive",
+    help="[Linux/macOS] Flag to allow directory and recursive deletes",
+    action="store_true",
+)
+rm_group.add_argument(
+    "-d",
+    "--dir",
+    dest="directory",
+    help="[Linux/macOS] Flag to allow empty directory deletes",
     action="store_true",
 )
 

--- a/falcon_toolkit/shell/prompt.py
+++ b/falcon_toolkit/shell/prompt.py
@@ -982,6 +982,10 @@ class RTRPrompt(Cmd):
         """Remove (delete) a file or directory."""
         if args.force:
             command = f"rm {args.path} -Force"
+        elif args.recursive:
+            command = f"rm {args.path} -r"
+        elif args.directory:
+            command = f"rm {args.path} -d"
         else:
             command = f"rm {args.path}"
 

--- a/falcon_toolkit/shell/prompt.py
+++ b/falcon_toolkit/shell/prompt.py
@@ -869,7 +869,11 @@ class RTRPrompt(Cmd):
     @with_argparser(PARSERS.mkdir, preserve_quotes=True)
     def do_mkdir(self, args):
         """Create a new directory."""
-        command = f"mkdir {args.directory}"
+        if args.parents:
+            command = f"mkdir -p {args.directory}"
+        else:
+            command = f"mkdir {args.directory}"
+
         self.send_generic_command(command)
 
     @with_argparser(PARSERS.mount, preserve_quotes=True)


### PR DESCRIPTION
This PR adds support for additional Linux and macOS specific RTR command options. And improves the help text.

1. Adds a mutually exclusive group to add support for the `-r` and `-d` flags to `rm` on Linux and macOS.
2. Adds support for the parents (`-p`) option to `mkdir` on Linux and macOS. Windows does not support this argument but creates parent directories by default.